### PR TITLE
feat: add 404 handler, link to docs

### DIFF
--- a/src/layout.janet
+++ b/src/layout.janet
@@ -18,7 +18,8 @@
     [:a {:href (url-for :home/index) :class "white no-underline"}
      "😇Joy"]]
    [:spacer]
-   [:a {:href "https://github.com/joy-framework/joy" :class "white"} "Github"]])
+   [:a {:href "https://github.com/joy-framework/joy" :class "white"} "Github"]
+   [:a {:href "http://joyframework.com/joy/" :class "white" :target "_BLANK"} "Docs"]])
 
 
 (defn app [response]

--- a/src/routes.janet
+++ b/src/routes.janet
@@ -1,5 +1,7 @@
 (import joy :prefix "")
 (import ./routes/home :as home)
+(import ./routes/not-found :as not-found)
 
 (defroutes app
-  [:get "/" home/index])
+  [:get "/" home/index]
+  [:get "/*" not-found/index])

--- a/src/routes/not-found.janet
+++ b/src/routes/not-found.janet
@@ -1,0 +1,13 @@
+(import joy :prefix "")
+
+(defn index [request]
+  [:div {:class "pt4 pt5-ns"}
+   [:vstack {:spacing "l"}
+    [:hstack {:spacing "l" :class "responsive"}
+     [:vstack {:spacing "l"}
+      [:div {:class "mw8 white"}
+       [:h1 {:class "white lh-title f1-ns f2"}
+        "404 - Not Found"]
+       [:div {:class "white lh-copy f4"}
+        [:span "We can't seem to find what you're looking for. Feel free to click on the Joy logo, or any of our navigation links!"]]]]]
+      ]])


### PR DESCRIPTION
## What does this do?

I've added a handler for all non-matched routes and placed a link to the docs site we deploy in the header. Hoping this is a step towards easier adoption for new users.